### PR TITLE
Fix imports for Compose beta08

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "br.com.devsrsouza"
-version = "0.6.0"
+version = "0.7.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/androidx/compose/material/icons/generator/Names.kt
+++ b/src/main/kotlin/androidx/compose/material/icons/generator/Names.kt
@@ -35,9 +35,9 @@ enum class PackageNames(val packageName: String) {
 object ClassNames {
     val Icons = PackageNames.MaterialIconsPackage.className("Icons")
     val ImageVector = PackageNames.VectorPackage.className("ImageVector")
-    val PathFillType = PackageNames.GraphicsPackage.className("PathFillType")
-    val StrokeCap = PackageNames.GraphicsPackage.className("StrokeCap")
-    val StrokeJoin = PackageNames.GraphicsPackage.className("StrokeJoin")
+    val PathFillType = PackageNames.GraphicsPackage.className("PathFillType", CompanionImportName)
+    val StrokeCap = PackageNames.GraphicsPackage.className("StrokeCap", CompanionImportName)
+    val StrokeJoin = PackageNames.GraphicsPackage.className("StrokeJoin", CompanionImportName)
 }
 
 /**
@@ -71,3 +71,5 @@ object MemberNames {
  * @return the [ClassName] of the given [classNames] inside this package.
  */
 fun PackageNames.className(vararg classNames: String) = ClassName(this.packageName, *classNames)
+
+private const val CompanionImportName = "Companion"


### PR DESCRIPTION
In Compose beta08 several classes that are used in vector graphics got transformed from `enum class` to `inline class` with values in `companion object`. See `StrokeCap` [change](https://cs.android.com/androidx/platform/frameworks/support/+/65a354677f8800c7a3f4e9505d99372d9572688a:compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/StrokeCap.kt;dlc=117f71a3c9a3b5f4aa502c5146e173af2aadf9bf) for example. This changes broke static imports in generated code since now they should be referenced by companion object instead of top-level class. This PR should fix those import references.