### PR TITLE
Move toKotlinPropertyName call to default param lambda

### DIFF
--- a/src/main/kotlin/br/com/devsrsouza/svg2compose/Svg2Compose.kt
+++ b/src/main/kotlin/br/com/devsrsouza/svg2compose/Svg2Compose.kt
@@ -26,7 +26,7 @@ object Svg2Compose {
         outputSourceDirectory: File,
         vectorsDirectory: File,
         type: VectorType = VectorType.SVG,
-        iconNameTransformer: IconNameTransformer = { it, _ -> it },
+        iconNameTransformer: IconNameTransformer = { it, _ -> it.toKotlinPropertyName() },
         allAssetsPropertyName: String = "AllAssets"
     ): ParsingResult {
         fun nameRelative(vectorFile: File) = vectorFile.relativeTo(vectorsDirectory).path
@@ -75,7 +75,7 @@ object Svg2Compose {
                         val icons: Map<VectorFile, Icon> = drawables.associate { (vectorFile, drawableFile) ->
                             vectorFile to Icon(
                                 iconNameTransformer(
-                                    drawableFile.nameWithoutExtension.toKotlinPropertyName().trim(),
+                                    drawableFile.nameWithoutExtension.trim(),
                                     groupName
                                 ),
                                 drawableFile.name,


### PR DESCRIPTION
I think having this call in the `iconNameTransformer` call is too opinionated, especially since not every set of icons exactly follow the Java file name convention, e.g. "icon_name_with_underscores".

This allows doing the transform more in the user-provided lambda. Otherwise, it can default to use `toKotlinPropertyName`.