### PR TITLE
Fix missing generatePreview parameter on IconWriter constructor

### DIFF
--- a/src/main/kotlin/br/com/devsrsouza/svg2compose/Svg2Compose.kt
+++ b/src/main/kotlin/br/com/devsrsouza/svg2compose/Svg2Compose.kt
@@ -88,6 +88,7 @@ object Svg2Compose {
                             icons.values,
                             groupClassName,
                             iconsPackage,
+                            generatePreview
                         )
 
                         val memberNames = writer.generateTo(outputSourceDirectory) { true }


### PR DESCRIPTION
Sorry, I removed by mistake `generatePreview` parameter from `IconWriter` constructor call when rebasing before raising https://github.com/DevSrSouza/svg-to-compose/pull/19 and the build for 0.9.0 failed becase of it 🙇 (seen on: https://jitpack.io/com/github/DevSrSouza/svg-to-compose/0.9.0/build.log).

It should work as expected after this change, sorry for any inconvenience.