### PR TITLE
feat: Add autoMirror rule parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,24 @@ Svg2Compose.parse(
 **Using in code**: `LineaIcons.Arrows.Buhttps://github.com/overpas/svg-to-compose-intellijttonUp`
 
 The project also generate an accessor for all yours assets, for the given example, it should be `LineaIcons.AllIcons` and it also generated for child groups `LineaIcons.Arrows.AllIcons`
+
+### Example 3: Configuring autoMirror
+
+`autoMirrorRule` is an optional parameter that allows you to set a rule to set the `autoMirror`
+property the icons.
+
+```kotlin
+ val svgDir = File("dist/icons/svg")
+val outputDir = File("src/main/kotlin")
+
+Svg2Compose.parse(
+    applicationIconPackage = "com.example",
+    accessorName = "Icons",
+    outputSourceDirectory = outputDir,
+    vectorsDirectory = svgDir,
+    type = VectorType.SVG,
+    iconNameTransformer = { name, group -> name.removePrefix(group) },
+    allAssetsPropertyName = "AllIcons",
+    autoMirrorRule = { name -> autoMirroredIconsList.contains(name.lowercase()) },
+)
+```

--- a/src/main/kotlin/androidx/compose/material/icons/generator/IconWriter.kt
+++ b/src/main/kotlin/androidx/compose/material/icons/generator/IconWriter.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.material.icons.generator
 
+import br.com.devsrsouza.svg2compose.AutoMirrorRule
 import br.com.devsrsouza.svg2compose.IconNameTransformer
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
@@ -32,7 +33,8 @@ class IconWriter(
     private val icons: Collection<Icon>,
     private val groupClass: ClassName,
     private val groupPackage: String,
-    private val generatePreview: Boolean
+    private val generatePreview: Boolean,
+    private val autoMirrorRule: AutoMirrorRule?,
 ) {
     /**
      * Generates icons and writes them to [outputSrcDirectory], using [iconNamePredicate] to
@@ -62,7 +64,8 @@ class IconWriter(
                 iconName,
                 groupPackage,
                 vector,
-                generatePreview
+                generatePreview,
+                autoMirrorRule?.let { autoMirror -> autoMirror(iconName) },
             ).createFileSpec(groupClass)
 
             fileSpec.writeTo(outputSrcDirectory)

--- a/src/main/kotlin/androidx/compose/material/icons/generator/VectorAssetGenerator.kt
+++ b/src/main/kotlin/androidx/compose/material/icons/generator/VectorAssetGenerator.kt
@@ -39,12 +39,14 @@ data class VectorAssetGenerationResult(
  * correct receiver object, and also for the package name of the generated file.
  * @param vector the parsed vector to generate VectorAssetBuilder commands for
  * @param generatePreview if true a preview for the icon will be created.
+ * @param autoMirrorSpec if not null, autoMirror parameter will be set with the value.
  */
 class VectorAssetGenerator(
     private val iconName: String,
     private val iconGroupPackage: String,
     private val vector: Vector,
-    private val generatePreview: Boolean
+    private val generatePreview: Boolean,
+    private val autoMirrorSpec: Boolean? = null
 ) {
     /**
      * @return a [FileSpec] representing a Kotlin source file containing the property for this
@@ -92,7 +94,10 @@ class VectorAssetGenerator(
                 "defaultWidth = ${width.withMemberIfNotNull}",
                 "defaultHeight = ${height.withMemberIfNotNull}",
                 "viewportWidth = ${viewportWidth}f",
-                "viewportHeight = ${viewportHeight}f"
+                "viewportHeight = ${viewportHeight}f",
+                autoMirrorSpec?.let { autoMirror ->
+                    "autoMirror = $autoMirror"
+                }
             )
         }
 

--- a/src/main/kotlin/br/com/devsrsouza/svg2compose/Svg2Compose.kt
+++ b/src/main/kotlin/br/com/devsrsouza/svg2compose/Svg2Compose.kt
@@ -9,6 +9,7 @@ import java.io.File
 import java.util.*
 
 typealias IconNameTransformer = (iconName: String, group: String) -> String
+typealias AutoMirrorRule = (iconName: String) -> Boolean
 
 object Svg2Compose {
 
@@ -21,6 +22,7 @@ object Svg2Compose {
      * @param accessorName will be usage to access the Vector in the code like `MyIconPack.IconName` or `MyIconPack.IconGroupDir.IconName`
      * @param generatePreview it will generate long side each group a String accessor called `Group.{allAssetsPropertyName}Named: Map<String, VectorImage>`
      *      for parent groups, it will find child group icons by `childgroup.icon_name`.
+     * @param autoMirrorRule used to add the autoMirror attribute to the generated vector based on the icon name
      */
     fun parse(
         applicationIconPackage: String,
@@ -32,6 +34,7 @@ object Svg2Compose {
         allAssetsPropertyName: String = "AllAssets",
         generatePreview: Boolean = true,
         generateStringAccessor: Boolean = false,
+        autoMirrorRule: AutoMirrorRule? = null,
     ): ParsingResult {
         fun nameRelative(vectorFile: File) = vectorFile.relativeTo(vectorsDirectory).path
 
@@ -92,7 +95,8 @@ object Svg2Compose {
                             icons.values,
                             groupClassName,
                             iconsPackage,
-                            generatePreview
+                            generatePreview,
+                            autoMirrorRule
                         )
 
                         val memberNames = writer.generateTo(outputSourceDirectory) { true }

--- a/src/test/kotlin/AutoMirrorTest.kt
+++ b/src/test/kotlin/AutoMirrorTest.kt
@@ -1,0 +1,35 @@
+package br.com.devsrsouza.svg2compose
+
+import java.io.File
+import java.util.Locale
+
+
+fun main() {
+    val iconTest = File("dist/icons/svg")
+    val src = File("build/generated-icons").apply { mkdirs() }
+
+    Svg2Compose.parse(
+        applicationIconPackage = "com.test",
+        accessorName = "Icons",
+        outputSourceDirectory = src,
+        vectorsDirectory = iconTest,
+        type = VectorType.SVG,
+        iconNameTransformer = { name, group ->
+            name.removePrefix(group)
+                .toUpperCamelCase()
+        },
+        allAssetsPropertyName = "AllIcons",
+        generatePreview = true,
+        autoMirrorRule = { name ->
+            name.contains("forward", ignoreCase = true) ||
+                    name.contains("backward", ignoreCase = true)
+        }
+    )
+}
+
+fun String.toUpperCamelCase(): String {
+    return this.split("[-_. ]".toRegex())
+        .joinToString("") { part ->
+            part.replaceFirstChar { it.titlecase(Locale.getDefault()) }
+        }
+}


### PR DESCRIPTION
### Context
RTL screens being managed by many applications, we might want to use and set the `autoMirror` parameter in ImageVector Builder for some icons that can simply be vertically swap.

Relates https://github.com/DevSrSouza/svg-to-compose/issues/31

I made a proposal of calculating the autoMirror rule by icon name only.

### Example
It could be used by checking the name content, like if there is "forward" or "backward". 

```
autoMirrorRule = { name ->
            name.contains("forward", ignoreCase = true) ||
                    name.contains("backward", ignoreCase = true)
        }
```

Or if the icon is part of a "rtl-compatible" list. 

```
autoMirrorRule = { name ->
      autoMirroredIconsList.contains(name.lowercase())
}
```

Or any other rule. 


### Any breaking change ? 
No 
The new parameter `autoMirrorRule` has a null default value that does not change previous generation. 
It only allow to add the parameter autoMirror if set with a rule. 
